### PR TITLE
Tell typescript to generate lf line endings for unix.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "newLine": "lf",
 
     /* Strict Type-Checking Options */
     "strict": true,


### PR DESCRIPTION
I believe this should fix Issue #12. As far as I can tell the resultant files still work on a windows host.