### PR TITLE
Adds flag for compressed output.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const options = new Command()
     .option('--no-reset-translation-state', 'prevent (re-)setting the translation state to new/initial for new/changed units')
     .option('--no-replace-apostrophe', 'prevent replacing of apostrophes (\') with "&apos;"')
     .option('-w, --overwrite-with-translated', 'overwrite target of destination with target of source, if it\'s translated and destination target not')
+    .option('-c, --compress-output', 'enables xmldoc compression for stripping indents and linebreaks in output.')
     .option('--debug', 'enable debug output')
     .parse()
     .opts();
@@ -32,6 +33,7 @@ const outString = merge(inFilesContent, destFileContent, {
     resetTranslationState: options.resetTranslationState,
     replaceApostrophe: options.replaceApostrophe,
     overwriteTargetWithTranslated: options.overwriteWithTranslated,
+    compressOutput: options.compressOutput,
 }, options.destinationFile);
 
 fs.writeFileSync(options.outputFile ?? options.destinationFile, outString, {encoding: 'utf8'});

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -12,6 +12,7 @@ type MergeOptions = {
     /** For untranslated units with initial state (state="initial" / state="new"), an updated source will be copied into the target (unless `newTranslationTargetsBlank='omit'/true`) */
     syncTargetsWithInitialState?: boolean,
     overwriteTargetWithTranslated?: boolean,
+    compressOutput?: boolean
 };
 
 const FUZZY_THRESHOLD = 0.2;
@@ -312,7 +313,7 @@ export function mergeWithMapping(inFilesContent: string | string[], destFileCont
 
     const mergedContent = xmlDeclaration + revertApostrophes(destDoc.toString({
         preserveWhitespace: true,
-        compressed: false
+        compressed: options?.compressOutput == true
     }), !options?.replaceApostrophe).replace(/^\s*[\r\n]/gm, '');
 
     return [mergedContent, idMapping];


### PR DESCRIPTION
Fixes #19 

This PR, add a flag that makes it possible to specify that xmldcc.toString() should output compressed text (no newlines and indentions). Default behavior is the current behavior (no compression).